### PR TITLE
Adds $host parameter to Factory::getInstance

### DIFF
--- a/src/Translator/Factory.php
+++ b/src/Translator/Factory.php
@@ -1,6 +1,7 @@
 <?php
 namespace SergioCarlos\IBMWatson\WatsonLanguageTranslator\Translator;
 
+use GuzzleHttp\Client as HttpClient;
 use SergioCarlos\IBMWatson\WatsonLanguageTranslator\Api\Transport as ApiTransport;
 use SergioCarlos\IBMWatson\WatsonLanguageTranslator\Translator\Client as TranslatorClient;
 
@@ -9,11 +10,17 @@ class Factory
     /**
      * @param string $username
      * @param string $password
+     * @param string $host
      * @return Client
      */
-    public static function getTranslator($username, $password)
+    public static function getTranslator($username, $password, $host = null)
     {
-        $apiTransport = new ApiTransport($username, $password);
+	if ($host) {
+	    $httpClient = new HttpClient([
+                'base_uri' => $host,
+            ]);
+	}
+        $apiTransport = new ApiTransport($username, $password, $httpClient);
         $translatorClient = new TranslatorClient($apiTransport);
         return $translatorClient;
     }


### PR DESCRIPTION
Provides easy way to customize client by hostname.
IBM cloud provides different host based on cloud location. Currently Factory cant be used if this customization is required.